### PR TITLE
.gitignore: Ignore __pycache__ inside modules too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
+*/__pycache__/
 *.py[cod]
 *$py.class
 


### PR DESCRIPTION
Added line to ignore the __pycache__ inside the sender and scraper
modules.